### PR TITLE
Fix no return statement in the non-void function (according g++8)

### DIFF
--- a/src/NodeAdapter.cpp
+++ b/src/NodeAdapter.cpp
@@ -200,6 +200,7 @@ bool NodeAdapter::init() {
       m_node = nullptr;
       return initInProcessNode();
   }
+  return initInProcessNode();
 }
 
 quint64 NodeAdapter::getLastKnownBlockHeight() const {


### PR DESCRIPTION
If the function is non-void, but no return, then when building with gcc8-c++, an incorrect assembler code is generated that falls in run-time. A more detailed description can be found here http://bugs.altlinux.org/36038.