### PR TITLE
Fix/unmixable

### DIFF
--- a/src/WalletAdapter.cpp
+++ b/src/WalletAdapter.cpp
@@ -99,7 +99,7 @@ quint64 WalletAdapter::getPendingBalance() const {
 
 quint64 WalletAdapter::getUnmixableBalance() const {
   try {
-    return m_wallet == nullptr ? 0 : m_wallet->dustBalance();
+    return m_wallet == nullptr ? 0 : m_wallet->unmixableBalance();
   } catch (std::system_error&) {
     return 0;
   }
@@ -382,17 +382,6 @@ void WalletAdapter::sendTransaction(const std::vector<CryptoNote::WalletLegacyTr
   }
 }
 
-void WalletAdapter::sweepDust(const std::vector<CryptoNote::WalletLegacyTransfer>& _transfers, quint64 _fee, const QString& _paymentId, quint64 _mixin) {
-  Q_CHECK_PTR(m_wallet);
-  try {
-    lock();
-    m_wallet->sendDustTransaction(_transfers, _fee, NodeAdapter::instance().convertPaymentId(_paymentId), _mixin, 0);
-    Q_EMIT walletStateChangedSignal(tr("Sweeping unmixable dust"));
-  } catch (std::system_error&) {
-    unlock();
-  }
-}
-
 quint64 WalletAdapter::estimateFusion(quint64 _threshold) {
   Q_CHECK_PTR(m_wallet);
   try {
@@ -473,7 +462,7 @@ void WalletAdapter::onWalletInitCompleted(int _error, const QString& _errorText)
   case 0: {
     Q_EMIT walletActualBalanceUpdatedSignal(m_wallet->actualBalance());
     Q_EMIT walletPendingBalanceUpdatedSignal(m_wallet->pendingBalance());
-    Q_EMIT walletUnmixableBalanceUpdatedSignal(m_wallet->dustBalance());
+    Q_EMIT walletUnmixableBalanceUpdatedSignal(m_wallet->unmixableBalance());
     Q_EMIT updateWalletAddressSignal(QString::fromStdString(m_wallet->getAddress()));
     Q_EMIT reloadWalletTransactionsSignal();
     Q_EMIT walletStateChangedSignal(tr("Ready"));

--- a/src/WalletAdapter.h
+++ b/src/WalletAdapter.h
@@ -55,7 +55,6 @@ public:
   size_t getUnlockedOutputsCount();
   bool isOpen() const;
   void sendTransaction(const std::vector<CryptoNote::WalletLegacyTransfer>& _transfers, quint64 _fee, const QString& _payment_id, quint64 _mixin);
-  void sweepDust(const std::vector<CryptoNote::WalletLegacyTransfer>& _transfers, quint64 _fee, const QString& _payment_id, quint64 _mixin);
   bool changePassword(const QString& _old_pass, const QString& _new_pass);
   void setWalletFile(const QString& _path);
   Crypto::SecretKey getTxKey(Crypto::Hash& txid);

--- a/src/gui/AccountFrame.cpp
+++ b/src/gui/AccountFrame.cpp
@@ -39,6 +39,8 @@ AccountFrame::AccountFrame(QWidget* _parent) : QFrame(_parent), m_ui(new Ui::Acc
     Qt::QueuedConnection);
   connect(&WalletAdapter::instance(), &WalletAdapter::walletCloseCompletedSignal, this, &AccountFrame::reset);
 
+  m_ui->m_unmixableBalanceLabel->setVisible(false);
+
   int id = QFontDatabase::addApplicationFont(":/fonts/mplusm");
   QString family = QFontDatabase::applicationFontFamilies(id).at(0);
   QFont monospace(family);
@@ -91,6 +93,11 @@ void AccountFrame::updateUnmixableBalance(quint64 _balance) {
   QStringList unmixableList = divideAmount(_balance);
 
   m_ui->m_unmixableBalanceLabel->setText(QString(tr("<p style=\"height:30\">Unmixable: <strong style=\"font-size:14px; color: #ffffff;\">%1</strong><small style=\"font-size:10px; color: #D3D3D3;\">%2 %3</small></p>")).arg(unmixableList.first()).arg(unmixableList.last()).arg(CurrencyAdapter::instance().getCurrencyTicker().toUpper()));
+  if (_balance != 0) {
+    m_ui->m_unmixableBalanceLabel->setVisible(true);
+  } else {
+    m_ui->m_unmixableBalanceLabel->setVisible(false);
+  }
 }
 
 void AccountFrame::reset() {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -141,7 +141,6 @@ private:
   Q_SLOT void showNormalIfMinimized(bool fToggleHidden = false);
   Q_SLOT void showMnemonicSeed();
   Q_SLOT void restoreFromMnemonicSeed();
-  Q_SLOT void sweepUnmixable();
   Q_SLOT void getBalanceProof();
   Q_SLOT void lockWalletWithPassword();
 

--- a/src/gui/SendFrame.h
+++ b/src/gui/SendFrame.h
@@ -41,7 +41,7 @@ private:
   QString remote_node_fee_address;
   quint64 remote_node_fee;
   quint64 total_amount;
-  quint64 dust_balance;
+  quint64 unmixable_balance;
 
   void sendTransactionCompleted(CryptoNote::TransactionId _id, bool _error, const QString& _error_text);
   void walletActualBalanceUpdated(quint64 _balance);

--- a/src/gui/ui/mainwindow.ui
+++ b/src/gui/ui/mainwindow.ui
@@ -260,7 +260,6 @@
     </property>
     <addaction name="m_encryptWalletAction"/>
     <addaction name="m_changePasswordAction"/>
-    <addaction name="m_sweepUnmixableAction"/>
     <addaction name="m_proofBalanceAction"/>
     <addaction name="separator"/>
     <addaction name="m_showMnemonicSeedAction"/>
@@ -1340,7 +1339,6 @@
   <slot>openConnectionSettings()</slot>
   <slot>openOptimizationSettings()</slot>
   <slot>showStatusInfo()</slot>
-  <slot>sweepUnmixable()</slot>
   <slot>getBalanceProof()</slot>
   <slot>lockWalletWithPassword()</slot>
   <slot>hideFusionTransactions(bool)</slot>


### PR DESCRIPTION
* Remove useless sweep unmixable menu option
* Add instead dialogue asking to set mixin to zero to 'send all' function
* Show unmixable balance only if it's present

Unmixable dust is supposed to be sent only in tx with zero mixin, so nagging about it is needed only when the user wants to sweep all his wallet balance.