### PR TITLE
Setup Xcode version for Github Actions build to support older macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,11 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@1.0
+        with:
+          xcode-version: '10'
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
         with:


### PR DESCRIPTION
Fixes wallets crashing on older macOS versions with error `Symbol not found: ____chkstk_darwin`