### PR TITLE
Some miner optimizations

### DIFF
--- a/src/CryptoNoteWrapper.cpp
+++ b/src/CryptoNoteWrapper.cpp
@@ -283,6 +283,10 @@ private:
     m_callback.lastKnownBlockHeightUpdated(*this, height);
   }
 
+  void poolChanged() override {
+    m_callback.poolChanged(*this);
+  }
+
   // INodeRpcProxyObserver
   void connectionStatusUpdated(bool _connected) override {
     m_callback.connectionStatusUpdated(_connected);
@@ -544,6 +548,10 @@ private:
 
   void lastKnownBlockHeightUpdated(uint32_t height) override {
     m_callback.lastKnownBlockHeightUpdated(*this, height);
+  }
+
+  void poolChanged() override {
+    m_callback.poolChanged(*this);
   }
 
   // dummy, used only for INodeRpcProxyObserver

--- a/src/CryptoNoteWrapper.h
+++ b/src/CryptoNoteWrapper.h
@@ -83,6 +83,7 @@ public:
   virtual void localBlockchainUpdated(Node& node, uint64_t height) = 0;
   virtual void lastKnownBlockHeightUpdated(Node& node, uint64_t height) = 0;
   virtual void connectionStatusUpdated(bool _connected) = 0;
+  virtual void poolChanged(Node& node) = 0;
 };
 
 Node* createRpcNode(const CryptoNote::Currency& currency, INodeCallback& callback, Logging::LoggerManager& logManager, const std::string& nodeHost, unsigned short nodePort, bool enableSSL);

--- a/src/Miner.cpp
+++ b/src/Miner.cpp
@@ -177,7 +177,7 @@ namespace WalletGui
 
       uint64_t total_hr = std::accumulate(m_last_hash_rates.begin(), m_last_hash_rates.end(), static_cast<uint64_t>(0));
       m_hash_rate = static_cast<float>(total_hr) / static_cast<float>(m_last_hash_rates.size());
-      qDebug() << "Hashrate: " << m_hash_rate << " H/s";
+      //qDebug() << "Hashrate: " << m_hash_rate << " H/s";
     }
     
     m_last_hr_merge_time = millisecondsSinceEpoch();

--- a/src/Miner.cpp
+++ b/src/Miner.cpp
@@ -76,7 +76,7 @@ namespace WalletGui
     m_do_mining(false),
     m_current_hash_rate(0),
     m_hash_rate(0),
-    m_update_block_template_interval(30),
+    m_update_block_template_interval(240),
     m_update_merge_hr_interval(2) {
   }
   //-----------------------------------------------------------------------------------------------------
@@ -127,7 +127,10 @@ namespace WalletGui
   }
   //-----------------------------------------------------------------------------------------------------
   bool Miner::request_block_template() {
-    qDebug() << "Requesting block template";
+    QDateTime date = QDateTime::currentDateTime();
+    QString formattedTime = date.toString("dd.MM.yyyy hh:mm:ss");
+    qDebug() << formattedTime << "Requesting block template";
+
     Block bl = boost::value_initialized<Block>();
     CryptoNote::difficulty_type di = 0;
     uint32_t height;

--- a/src/Miner.h
+++ b/src/Miner.h
@@ -45,6 +45,7 @@ namespace WalletGui {
     ~Miner();
 
     bool set_block_template(const Block& bl, const difficulty_type& diffic);
+    bool request_block_template();
     bool on_block_chain_update();
     bool start(size_t threads_count);
     double get_speed();
@@ -59,7 +60,6 @@ namespace WalletGui {
 
   private:
     bool worker_thread(uint32_t th_local_index);
-    bool request_block_template();
 
     struct miner_config
     {

--- a/src/NodeAdapter.cpp
+++ b/src/NodeAdapter.cpp
@@ -354,6 +354,9 @@ void NodeAdapter::connectionStatusUpdated(bool _connected) {
   Q_EMIT connectionStatusUpdatedSignal(_connected);
 }
 
+void NodeAdapter::poolChanged(Node& _node) {
+  Q_EMIT poolChangedSignal();
+}
 
 bool NodeAdapter::initInProcessNode() {
   Q_ASSERT(m_node == nullptr);

--- a/src/NodeAdapter.h
+++ b/src/NodeAdapter.h
@@ -72,6 +72,7 @@ public:
   void localBlockchainUpdated(Node& _node, uint64_t _height) Q_DECL_OVERRIDE;
   void lastKnownBlockHeightUpdated(Node& _node, uint64_t _height) Q_DECL_OVERRIDE;
   void connectionStatusUpdated(bool _connected) Q_DECL_OVERRIDE;
+  void poolChanged(Node& _node) Q_DECL_OVERRIDE;
 
   CryptoNote::INode* getNode();
   System::Dispatcher& getDispatcher();
@@ -94,6 +95,7 @@ Q_SIGNALS:
   void lastKnownBlockHeightUpdatedSignal(quint64 _height);
   void nodeInitCompletedSignal();
   void peerCountUpdatedSignal(quintptr _count);
+  void poolChangedSignal();
   void initNodeSignal(WalletGui::Node** _node, const CryptoNote::Currency* currency, INodeCallback* _callback, Logging::LoggerManager* _loggerManager,
     const CryptoNote::CoreConfig& _coreConfig, const CryptoNote::NetNodeConfig& _netNodeConfig, const CryptoNote::RpcServerConfig& _rpcServerConfig);
   void deinitNodeSignal(WalletGui::Node** _node);

--- a/src/gui/MiningFrame.cpp
+++ b/src/gui/MiningFrame.cpp
@@ -130,7 +130,7 @@ void MiningFrame::timerEvent(QTimerEvent* _event) {
     QString formattedTime = date.toString("dd.MM.yyyy hh:mm:ss");
     qDebug() << formattedTime << "Event, requesting block template";
 
-    m_miner->request_block_template();
+    m_miner->on_block_chain_update();
   }
 
   QFrame::timerEvent(_event);

--- a/src/gui/MiningFrame.cpp
+++ b/src/gui/MiningFrame.cpp
@@ -27,7 +27,7 @@
 namespace WalletGui {
 
 const quint32 HASHRATE_TIMER_INTERVAL = 1000;
-const quint32 MINER_ROUTINE_TIMER_INTERVAL = 60000;
+const quint32 MINER_ROUTINE_TIMER_INTERVAL = 240000;
 
 MiningFrame::MiningFrame(QWidget* _parent) :
     QFrame(_parent), m_ui(new Ui::MiningFrame),
@@ -126,7 +126,11 @@ void MiningFrame::timerEvent(QTimerEvent* _event) {
     return;
   }
   if (_event->timerId() == m_minerRoutineTimerId) {
-    m_miner->on_idle();
+    QDateTime date = QDateTime::currentDateTime();
+    QString formattedTime = date.toString("dd.MM.yyyy hh:mm:ss");
+    qDebug() << formattedTime << "Event, requesting block template";
+
+    m_miner->request_block_template();
   }
 
   QFrame::timerEvent(_event);
@@ -239,6 +243,10 @@ void MiningFrame::setMiningThreads() {
 }
 
 void MiningFrame::onBlockHeightUpdated() {
+  QDateTime date = QDateTime::currentDateTime();
+  QString formattedTime = date.toString("dd.MM.yyyy hh:mm:ss");
+  qDebug() << formattedTime << "Blockchain update, requesting block template";
+
   m_miner->on_block_chain_update();
 
   quint64 difficulty = NodeAdapter::instance().getDifficulty();
@@ -279,8 +287,11 @@ void MiningFrame::coreDealTurned(int _cores) {
 }
 
 void MiningFrame::poolChanged() {
-  qDebug() << "Mempool changed, requesting block template";
-  m_miner->on_idle();
+  QDateTime date = QDateTime::currentDateTime();
+  QString formattedTime = date.toString("dd.MM.yyyy hh:mm:ss");
+  qDebug() << formattedTime << "Mempool changed, requesting block template";
+
+  m_miner->on_block_chain_update();
 }
 
 }

--- a/src/gui/MiningFrame.cpp
+++ b/src/gui/MiningFrame.cpp
@@ -81,6 +81,7 @@ MiningFrame::MiningFrame(QWidget* _parent) :
   connect(&WalletAdapter::instance(), &WalletAdapter::walletPendingBalanceUpdatedSignal, this, &MiningFrame::updatePendingBalance, Qt::QueuedConnection);
   connect(&WalletAdapter::instance(), &WalletAdapter::walletSynchronizationCompletedSignal, this, &MiningFrame::onSynchronizationCompleted, Qt::QueuedConnection);
   connect(&NodeAdapter::instance(), &NodeAdapter::localBlockchainUpdatedSignal, this, &MiningFrame::onBlockHeightUpdated, Qt::QueuedConnection);
+  connect(&NodeAdapter::instance(), &NodeAdapter::poolChangedSignal, this, &MiningFrame::poolChanged,Qt::QueuedConnection);
   connect(&*m_miner, &Miner::minerMessageSignal, this, &MiningFrame::updateMinerLog, Qt::QueuedConnection);
 }
 
@@ -275,6 +276,11 @@ void MiningFrame::coreDealTurned(int _cores) {
   QTimer::singleShot(600, [this, _cores]() {
     Settings::instance().setMiningThreads(_cores);
   } );
+}
+
+void MiningFrame::poolChanged() {
+  qDebug() << "Mempool changed, requesting block template";
+  m_miner->on_idle();
 }
 
 }

--- a/src/gui/MiningFrame.cpp
+++ b/src/gui/MiningFrame.cpp
@@ -27,7 +27,7 @@
 namespace WalletGui {
 
 const quint32 HASHRATE_TIMER_INTERVAL = 1000;
-const quint32 MINER_ROUTINE_TIMER_INTERVAL = 240000;
+const quint32 MINER_ROUTINE_TIMER_INTERVAL = 60000;
 
 MiningFrame::MiningFrame(QWidget* _parent) :
     QFrame(_parent), m_ui(new Ui::MiningFrame),

--- a/src/gui/MiningFrame.h
+++ b/src/gui/MiningFrame.h
@@ -67,6 +67,7 @@ private:
   Q_SLOT void updatePendingBalance(quint64 _balance);
   Q_SLOT void updateMinerLog(const QString& _message);
   Q_SLOT void coreDealTurned(int _cores);
+  Q_SLOT void poolChanged();
 };
 
 }


### PR DESCRIPTION
- Use one block template update routine (we may also delete leftover in Miner)
- Update block template on mempool change

This should slightly improve / stabilize hashrate and smoothen its chart